### PR TITLE
fix end-pr.sh

### DIFF
--- a/cs/end-pr.sh
+++ b/cs/end-pr.sh
@@ -15,8 +15,6 @@ if [ $# -gt 0 ]; then
   exit 1
 fi
 
-source ./common.sh
-
 if git remote | grep -q 'upstream'; then
   remote=upstream
 else


### PR DESCRIPTION
end-pr で common.sh が見つからないエラーが発生したので修正しました。
前回のコミットで `source $(dirname $0)/common.sh` が追加されていましたが、その下に `source ./common.sh`が残ったままでしたので、これを削除しました。
https://github.com/procube-open/cs-tools/pull/7/commits/b1c928604427ec78e1941860e63f78313c3a492b#diff-6a12eb62b66c23b8e9264bccf227efe997fe0874568a651daeaa49ab843f39b8